### PR TITLE
Fix result CSV file, use separator from language file or user prefs

### DIFF
--- a/SurveyExport/Kernel/Modules/AgentSurveyExport.pm
+++ b/SurveyExport/Kernel/Modules/AgentSurveyExport.pm
@@ -101,16 +101,24 @@ sub Run {
 	push @CSVData, \@Data;
     }
 
+    # get Separator from language file
+    my $UserCSVSeparator = $Self->{LayoutObject}->{LanguageObject}->{Separator};
+
+    if ( $Self->{ConfigObject}->Get('PreferencesGroups')->{CSVSeparator}->{Active} ) {
+        my %UserData = $Self->{UserObject}->GetUserData( UserID => $Self->{UserID} );
+        $UserCSVSeparator = $UserData{UserCSVSeparator};
+    }
+
     my $CSV = $Self->{CSVObject}->Array2CSV(
 	Head      => \@CSVHead,
 	Data      => \@CSVData,
-	Separator => ';',
+	Separator => $UserCSVSeparator,
     );
 
     return $Self->{LayoutObject}->Attachment(
 	Filename    => "survey.csv",
 	ContentType => "text/csv; charset=utf8",
-	Content     => "\x{EF}\x{BB}\x{BF}" . $CSV,
+	Content     => $CSV,
     );
 }
 


### PR DESCRIPTION
- Remove byte order mark from UTF8 file.
- Get CSV separator from language file or user preference.

Hi, 

I found someone on the OTRS forums reported an issue with CSV file export using your module (which is when I found out about your module in the first place...) ref: [http://forums.otterhub.org/viewtopic.php?f=61&p=85915]

Also I use the CSV separator from the language file (which is for instance a comma instead of a semicolon in the US), plus read it from user prefs if that is active. 

Would you consider contributing your enhancement to the 'main' survey package? We now have the Survey repo on Github as well. https://github.com/OTRS/Survey - it would make the Survey module better for everyone and it would release you of the 'burden' of porting the module to new framework versions.

Please let me know if you'd be interested.

Mike
